### PR TITLE
Fix typo in new _change_options function

### DIFF
--- a/js/src/sigplot_ext.js
+++ b/js/src/sigplot_ext.js
@@ -67,7 +67,7 @@ var SigPlotView = widgets.DOMWidgetView.extend({
       } else {
         this.plot.change_settings(new_options);   
       }
-    }
+    },
     
     /**
      * Handles plotting both 1-D (xplot) and 2-D arrays (xraster)


### PR DESCRIPTION
There's just a missing comma after the definition of the new `_change_options` listener.

Not sure if there's a "build" test I should add for this somewhere?