### PR TITLE
Minor package.json edits

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -18,6 +18,7 @@
     "prepare": "webpack",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "license": "Apache-2.0",
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-core": "^6.25.0",
@@ -27,13 +28,13 @@
     "style-loader": "^0.18.2",
     "css-loader": "^0.28.4",
     "json-loader": "^0.5.4",
-    "webpack": "^1.12.14"
+    "webpack": "^2"
   },
   "dependencies": {
     "britecharts": "^1.7.2",
     "d3": "^4.9.1",
     "jupyter-js-widgets": "^2.1.4",
-    "sigplot": "^2.0.0-rc7",
+    "sigplot": "^2.0.0-rc8",
     "underscore": "^1.8.3"
   }
 }


### PR DESCRIPTION
Address a couple of warnings from the build process, and update SigPlot dependency to 2.0.0-rc8.

I wasn't sure whether it was actually appropriate to update the license or the Webpack require--both just gave me warnings from npm that I didn't want to keep ignoring. 

If you'd rather the SigPlot version bump be separated into its own commit, let me know.