### PR TITLE
Fix #24 and #21

### DIFF
--- a/example/JupyterSigplot.ipynb
+++ b/example/JupyterSigplot.ipynb
@@ -4,14 +4,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# SigPlot Jupyter Notebook Extension! [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/amatma/jupyter_sigplot/master?filepath=SigPlotExtensionTest.ipynb)\n",
+    "# SigPlot Jupyter Notebook Extension!\n",
+    "\n",
+    "[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/amatma/jupyter_sigplot/master?filepath=SigPlotExtensionTest.ipynb)\n",
     "\n",
     "## Installation (If not running the notebook on [myBinder](https://mybinder.org/v2/gh/amatma/jupyter_sigplot/master?filepath=SigPlotExtensionTest.ipynb))\n",
     "- Download extension from [GitHub](https://github.com/amatma/jupyter-xm-magic)\n",
     "- Install Python 2.6+ or 3.5+\n",
     "- Install `pip` (usually bundled with Python)\n",
     "- Install Jupyter using `pip`\n",
-    "- Note: you do not need X-MIDAS installed to use  [SigPlot](https://github.com/lgsinnovations/sigplot).\n",
     "\n",
     "```\n",
     "pip install jupyter\n",
@@ -20,8 +21,7 @@
     "- Install the SigPlot Jupyter Notebook extension (run the following in order)\n",
     "\n",
     "```\n",
-    "[/path/to/jupyter_sigplot]$ python setup.py build\n",
-    "[/path/to/jupyter_sigplot]$ pip install -e .\n",
+    "[/path/to/jupyter_sigplot]$ python setup.py install\n",
     "[/path/to/jupyter_sigplot]$ jupyter nbextension install --py --symlink --sys-prefix jupyter_sigplot\n",
     "[/path/to/jupyter_sigplot]$ jupyter nbextension enable jupyter_sigplot --py --sys-prefix\n",
     "```\n",
@@ -31,23 +31,38 @@
     "$ jupyter notebook\n",
     "```\n",
     "\n",
+    "- (Note: you do not need X-MIDAS installed to use  [SigPlot](https://github.com/lgsinnovations/sigplot).)\n",
+    "\n",
     "## SigPlot Usage\n",
-    "- Sigplot(args*, kwargs*) - creates a sigplot with each arg as input data and kwargs as options\n",
-    "- overlay_array(data) - adds an array of numbers to the sigplot's input data\n",
-    "- overlay_href(path) - adds data from a file to the sigplot\n",
-    "- change_settings(kwargs*) - changes the options of the sigplot\n",
-    "- plot(args*) - displays an interactive sigplot"
+    "- `Sigplot(args*, kwargs*)` - creates a sigplot with each arg as input data and kwargs as options\n",
+    "- `overlay_array(data)` - adds an array of numbers to the sigplot's input data\n",
+    "- `overlay_href(path)` - adds data from a file to the sigplot\n",
+    "- `change_settings(kwargs*)` - changes the options of the sigplot\n",
+    "- `plot(args*)` - displays an interactive sigplot"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The only import you _need_ for plotting is `jupyter_sigplot.sigplot.SigPlot`.\n",
+    "from jupyter_sigplot.sigplot import SigPlot\n",
+    "\n",
+    "# We'll import `numpy` too to show how to plot a `numpy` array.\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f2d7d6447f0f485abf77bedc35b459c4",
+       "model_id": "bbfc31ee2b574e32880468ca64c160e8",
        "version_major": 2,
        "version_minor": 0
       },
@@ -61,7 +76,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f2d7d6447f0f485abf77bedc35b459c4",
+       "model_id": "bbfc31ee2b574e32880468ca64c160e8",
        "version_major": 2,
        "version_minor": 0
       },
@@ -74,25 +89,34 @@
     }
    ],
    "source": [
-    "from jupyter_sigplot.sigplot import *\n",
-    "import numpy as np\n",
-    "plot= SigPlot(noxaxis=True, noyaxis=True)\n",
+    "# self-explanatory, but we're instantiating a `SigPlot` object\n",
+    "# and saying show the x and y axes.\n",
+    "plot = SigPlot(noxaxis=True, noyaxis=True)\n",
+    "\n",
+    "# Multiple `overlay_*` calls will layer on top of one-another\n",
     "plot.overlay_array(np.sin(np.arange(0, 20, 0.01)))\n",
     "plot.overlay_array(np.cos(np.arange(0, 20, 0.01)))\n",
+    "\n",
+    "# `plot()` is the guy that will actually render the layers\n",
     "plot.plot()\n",
+    "\n",
+    "# you can change settings after the plot is instantiated,\n",
+    "# so we'll disable the x and y axis labels\n",
     "plot.change_settings(noxaxis=False, noyaxis=False, xi=True)\n",
+    "\n",
+    "# ...and replot!\n",
     "plot.plot()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0f19e2a32ece4567981432717df1208d",
+       "model_id": "74e70f17b8664b6794efb6fecf84c3f6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -105,20 +129,24 @@
     }
    ],
    "source": [
-    "plot= SigPlot(noxaxis=True)\n",
+    "plot = SigPlot(noxaxis=True)\n",
+    "\n",
+    "# overlay_href() can accept a local Jupyter file or an arbitrary URI;\n",
+    "# if it's an http or https URI, it will copy the file locally to\n",
+    "# avoid dealing with cross-origin resource sharing (CORS)\n",
     "plot.overlay_href(\"http://sigplot.lgsinnovations.com/dat/pulse.tmp\")\n",
     "plot.plot()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4d06c20d636542ecb293bbd6d9f15ce0",
+       "model_id": "fc1ac15dbcb140deba6181f807de4979",
        "version_major": 2,
        "version_minor": 0
       },
@@ -131,7 +159,68 @@
     }
    ],
    "source": [
-    "plot= SigPlot(\"sin.tmp\")\n",
+    "# note: you can also instantiate a `SigPlot` object with an array or href too,\n",
+    "# and it will add it as a layer\n",
+    "plot = SigPlot(\"http://sigplot.lgsinnovations.com/dat/sin.tmp\")\n",
+    "plot.overlay_href(\"http://sigplot.lgsinnovations.com/dat/pulse.tmp\")\n",
+    "plot.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8e25767247564553bfa20f398ec6ba46",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "SigPlot()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# once the resource is local,\n",
+    "# you can just refer to the filename\n",
+    "plot = SigPlot(\"sin.tmp\")\n",
+    "plot.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "25bbd2e6b3a84f8fbd18efa0cb94bde4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "SigPlot()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# You can also instantiate the `SigPlot()` with multiple\n",
+    "# hrefs or arrays\n",
+    "plot = SigPlot(\n",
+    "    \"http://sigplot.lgsinnovations.com/dat/sin.tmp\",\n",
+    "    \"http://sigplot.lgsinnovations.com/dat/pulse.tmp\",\n",
+    "    np.arange(0, 4, .01)\n",
+    ")\n",
     "plot.plot()"
    ]
   },
@@ -143,7 +232,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "39405ba451494dd3b509d4575a4045dc",
+       "model_id": "91691c08163542cf97a09f9b4e750388",
        "version_major": 2,
        "version_minor": 0
       },
@@ -156,8 +245,10 @@
     }
    ],
    "source": [
-    "plot= SigPlot(\"http://sigplot.lgsinnovations.com/dat/sin.tmp\")\n",
-    "plot.overlay_href(\"http://sigplot.lgsinnovations.com/dat/pulse.tmp\")\n",
+    "# penny.prm is a type-2000 file, meaning it's layed out as\n",
+    "# a 2-dimensional matrix, so `plot()` will by default plot each row\n",
+    "# individually in a 1-D plot\n",
+    "plot = SigPlot(\"http://sigplot.lgsinnovations.com/dat/penny.prm\")\n",
     "plot.plot()"
    ]
   },
@@ -169,7 +260,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "10887334e4104fc3af68160ddeb4d7ac",
+       "model_id": "db72a4c1cca44a7d8a36d1589db4515e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -182,71 +273,22 @@
     }
    ],
    "source": [
-    "plot=SigPlot(\"http://sigplot.lgsinnovations.com/dat/sin.tmp\", \"http://sigplot.lgsinnovations.com/dat/pulse.tmp\",\n",
-    "    np.arange(0, 4, .01)\n",
-    ")\n",
-    "plot.plot()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "291ce05fca664ae8a0425ee43b208c1f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "plot=SigPlot(\"http://sigplot.lgsinnovations.com/dat/penny.prm\")\n",
-    "plot.plot()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "53477debf7ef47469e9db41912f69125",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "plot=SigPlot(\"http://sigplot.lgsinnovations.com/dat/penny.prm\")\n",
+    "plot = SigPlot(\"http://sigplot.lgsinnovations.com/dat/penny.prm\")\n",
+    "\n",
+    "# if we specifically tell it to `plot('2D')`, it will plot it as\n",
+    "# a heatmap/raster.\n",
     "plot.plot(\"2D\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "da21712a060d4cebb7a169dd09089216",
+       "model_id": "f670d18bb89747599e3f29cd925eada2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -259,20 +301,24 @@
     }
    ],
    "source": [
-    "plot=SigPlot()\n",
+    "plot = SigPlot()\n",
+    "\n",
+    "# we can also force SigPlot to plot 1-dimensional arrays\n",
+    "# as a heatmap/raster with `plot('2D') and setting `subsize`\n",
+    "# to how many elements should be in each row\n",
     "plot.overlay_array([1,2,3,2,3,4,1,2,3])\n",
     "plot.plot(\"2D\", subsize=3)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "42fd08349f96465b972814b4e75c9144",
+       "model_id": "44f56a823e53412f8883dc2d3856bfe1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -285,20 +331,22 @@
     }
    ],
    "source": [
-    "plot=SigPlot()\n",
+    "plot = SigPlot()\n",
     "plot.overlay_array([1,2,3,2,3,4,1,2,3])\n",
+    "\n",
+    "# note how changing subsize changes the output\n",
     "plot.plot(\"2D\", subsize=5)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8634645e15b143afa37c6fa73dafd076",
+       "model_id": "03cef7d932914b1b9f97ab0d94e08cbe",
        "version_major": 2,
        "version_minor": 0
       },
@@ -311,9 +359,38 @@
     }
    ],
    "source": [
-    "plot=SigPlot()\n",
+    "plot = SigPlot()\n",
+    "\n",
+    "# alternatively, you can just pass a 2-dimensional array/list\n",
+    "# and as long as \"2D\" is passed, it will plot it correctly\n",
     "plot.overlay_array([[1,2,3],[2,3,4],[1,2,3]])\n",
     "plot.plot(\"2D\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5694466b031342d0b72145bdbdb57a32",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "SigPlot()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# also, hrefs can be '|'-delimited\n",
+    "plot = SigPlot('sin.tmp|pulse.tmp')\n",
+    "plot.plot()"
    ]
   },
   {
@@ -340,7 +417,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.5"
+   "version": "2.7.15"
   }
  },
  "nbformat": 4,

--- a/js/src/sigplot_ext.js
+++ b/js/src/sigplot_ext.js
@@ -100,14 +100,8 @@ var SigPlotView = widgets.DOMWidgetView.extend({
       if (old_href_obj === href_obj) {
         return;
       } else {
-        var url = href_obj.filename;
-        if (!url.startsWith("http")) {
-          // Server-side widget gave us a name like data/foo.tmp;
-          // Jupyter will serve this for us at the `files` route
-          url = window.location.origin + "/files/" + url;
-        }
         this.plot.overlay_href(
-          url,
+          href_obj.filename,
           null,
           {layerType: href_obj.layerType}
         );


### PR DESCRIPTION
#24 is the underlying bug that is causing #21 to not work. The fix is to remove the explicit URL-setting in sigplot_ext.js (shown below)

```javascript
var url = href_obj.filename;	
if (!url.startsWith("http")) {	
    // Server-side widget gave us a name like data/foo.tmp;	
    // Jupyter will serve this for us at the `files` route	
    url = window.location.origin + "/files/" + url;	
}
```

because just using `href_obj.filename` will correctly locate the resource.

This removes unnecessary complexity required by sigplot.py to track where the Jupyter Notebook server was launched vs where the running notebook is located. As long as the passed resource is relative to the launched notebook, the client should be able to find it.