### PR TITLE
Feat/pathname resolvers

### DIFF
--- a/jupyter_sigplot/sigplot.py
+++ b/jupyter_sigplot/sigplot.py
@@ -51,12 +51,14 @@ class SigPlot(widgets.DOMWidget):
     oldHrefs = List().tag(sync=True)
     imageOutput = Unicode("img").tag(sync=True)
     dimension = 1
+    # Sequence of callables used by _prepare_file_input to resolve relative
+    # pathnames
+    path_resolvers = []
 
     def __init__(self, *args, **kwargs):
         self.inputs = []
         self.hrefs = []
         self.arrays = []
-        self.options = kwargs
         # Where to look for data, and where to cache/symlink remote resources
         # that the server or client cannot access directly.
         #
@@ -64,7 +66,19 @@ class SigPlot(widgets.DOMWidget):
         # effective root of the notebook server, not just this kernel. See
         # Github issue #17. I expect that we'll be able to just set
         # self.data_dir to the notebook server's cwd/root and be good to go.
-        self.data_dir = ''
+        self.data_dir = kwargs.pop('data_dir', '')
+
+        if 'path_resolvers' in kwargs:
+            # Don't use pop()+default because we don't want to override class-
+            # level values when not specified here, and we do want to allow
+            # specifying None to remove any resolvers.
+            #
+            # Note that instance-level resolvers will override class-level
+            # resolvers per Python semantics.
+            self.path_resolvers = kwargs.pop('path_resolvers')
+
+        # Whatever's left is meant for the client half of the widget
+        self.options = kwargs
         for arg in args:
             if isinstance(arg, StringType):
                 self.overlay_href(arg)
@@ -132,7 +146,9 @@ class SigPlot(widgets.DOMWidget):
         >>> display(plot)
         >>> plot.overlay_href('foo.tmp', layer_type='2D')
         """
-        for pi in _prepare_href_input(fpath, self.data_dir):
+        for pi in _prepare_href_input(fpath,
+                                      self.data_dir,
+                                      self.path_resolvers):
             obj = {
                 "filename": pi,
                 "layerType": layer_type,
@@ -164,7 +180,9 @@ class SigPlot(widgets.DOMWidget):
         # only add to self.inputs if we're not yet rendered, and otherwise
         # jump right to _show_href_internal; or clear self.inputs after we've
         # consumed it, add to self.inputs here, and trigger self.plot()
-        prepared_paths = _prepare_href_input(paths, self.data_dir)
+        prepared_paths = _prepare_href_input(paths,
+                                             self.data_dir,
+                                             self.path_resolvers)
         self.inputs.extend(prepared_paths)
 
     def display_as_png(self):
@@ -301,23 +319,35 @@ def _prepare_http_input(url, local_dir):
     return local_fname
 
 
-def _unravel_path(path):
+def _unravel_path(path, resolvers=None):
+    """
+    Expand user directories and environment variables in <path>, then run
+    through callables in <resolvers>. Does NOT call realpath / abspath unless
+    that happens to be in <resolvers>.
+    """
     import os.path as p
-    return p.realpath(p.expanduser(p.expandvars(path)))
+    unraveled = p.expanduser(p.expandvars(path))
+    if resolvers:
+        for f in resolvers:
+            unraveled = f(unraveled)
+    return unraveled
 
 
 def _local_name_for_file(fpath, local_dir):
     """
-    Generate a name for the given a file path under <local_dir>
+    Generate a name for the given a file path under <local_dir> . Expects
+    arguments to already be unraveled.
 
     :return: tuple (path, is_local) where
              <path> is a path starting at <local_dir> suitable for storing
-                    a link to, or the contents of, <fname>
+                    a link to, or the contents of, <fpath>
              <is_local> is a bool, true iff <fpath> is already a
                     descendant of <local_dir>
 
     .. note:: Different <fname> values may map to the same local path
     """
+    import os.path as p
+
     if not isinstance(fpath, StringType):
         raise TypeError("fpath must be of type str (%r has type %s)" %
                         (fpath, type(fpath)))
@@ -329,34 +359,35 @@ def _local_name_for_file(fpath, local_dir):
     if not fpath:
         raise ValueError("Path %r is not a valid filename" % fpath)
 
-    # TODO (sat 2018-11-07): Consider adding an optional <resolver> callable
-    # to transform <fname> into a full path. Could implement the current
-    # _unravel_path logic, but could also implement a domain-specific search
-    # path for unadorned filenames, etc.
-    fpath = _unravel_path(fpath)
-    abs_local_dir = _unravel_path(local_dir)
+    abs_fpath = p.realpath(fpath)
+    abs_local_dir = p.realpath(local_dir)
 
     # A bit clunky but works okay for now
-    if fpath.startswith(abs_local_dir):
+    if abs_fpath.startswith(abs_local_dir):
         is_local = True
-        local_relative_path = fpath[len(abs_local_dir + os.path.sep):]
+        local_relative_path = abs_fpath[len(abs_local_dir + os.path.sep):]
     else:
         is_local = False
-        local_relative_path = os.path.basename(fpath)
+        local_relative_path = os.path.basename(abs_fpath)
 
     return (os.path.join(local_dir, local_relative_path), is_local)
 
 
-def _prepare_file_input(orig_fname, local_dir):
+def _prepare_file_input(orig_fname, local_dir, resolvers=None):
     """
     Given an arbitrary filename, determine whether that file is a child of
     <local_dir>. If not, create a symlink under <local_dir> that points to the
     original file, so the Jupyter server can resolve it.
 
+    :param resolvers: sequence of callables to be applied, in order, to
+    <orig_fname>. Could be used to normalize case, look up bare paths in
+    system- specific search paths, etc. <orig_fname> will have environment
+    variables and user directories expanded before it is given to the first
+    resolver.
+
     :return: A filename in the local filesystem, under <local_dir>
     """
-    import os.path as p
-    input_path = _unravel_path(orig_fname)
+    input_path = _unravel_path(orig_fname, resolvers)
 
     # TODO (sat 2018-11-07): Handle errors more thoroughly
     # * unable to make local path
@@ -368,13 +399,11 @@ def _prepare_file_input(orig_fname, local_dir):
     local_fname, is_local = _local_name_for_file(input_path, local_dir)
     if not is_local:
         try:
-            # If we link the unraveled path, then relative names like
-            # ../foo.tmp will become obscured. So we prefer to keep the target
-            # as raveled as possible. But we still need to make sure that we
-            # handle user specifications like ~someone and environment
-            # variables.
-            linkpath = p.expanduser(p.expandvars(orig_fname))
-            os.symlink(linkpath, local_fname)
+            # Note that _unravel_path keeps relative names like ../foo.tmp
+            # will as is, only applying user specifications like ~someone,
+            # environment variables, and any explicit resolvers. This is
+            # intended to make links as human-comprehensible as possible.
+            os.symlink(input_path, local_fname)
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
@@ -398,7 +427,7 @@ def _split_inputs(orig_inputs):
     return inputs
 
 
-def _prepare_href_input(orig_inputs, local_dir):
+def _prepare_href_input(orig_inputs, local_dir, resolvers=None):
     """
     Given an input specification containing one or more filesystem paths and
     URIs separated by '|', prepare each one according to its type.
@@ -411,7 +440,11 @@ def _prepare_href_input(orig_inputs, local_dir):
         if oi.startswith("http"):
             pi = _prepare_http_input(oi, local_dir)
         else:
-            pi = _prepare_file_input(oi, local_dir)
+            # TODO (sat 2019-01-08): This `resolvers` argument  feels like a
+            # bad factoring, since only one branch uses it; may want to move
+            # _prepare_href_input to a class member or else replace with a
+            # split+dispatch idiom at the point of call.
+            pi = _prepare_file_input(oi, local_dir, resolvers)
         prepared.append(pi)
 
     return prepared

--- a/jupyter_sigplot/sigplot.py
+++ b/jupyter_sigplot/sigplot.py
@@ -27,8 +27,8 @@ from IPython.display import (
 )
 
 
-py3k = sys.version_info[0] == 3
-if py3k:
+_py3k = sys.version_info[0] == 3
+if _py3k:
     StringType = (str, bytes)
 else:
     StringType = (basestring, )

--- a/test/test_jupyter_sigplot.py
+++ b/test/test_jupyter_sigplot.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import os
-import sys
 
 import pytest
 from mock import patch
@@ -380,11 +379,10 @@ def test_overlay_file_bad_type():
         plot.overlay_file(path)
 
 
-def test_unravel_path():
+def test_unravel_path_no_resolvers():
     import time
     from jupyter_sigplot.sigplot import _unravel_path
 
-    cwd_full = os.getcwd()
     tilde_full = os.path.expanduser('~')
 
     # Go all the way through the environment instead of a mock to be sure the
@@ -395,36 +393,94 @@ def test_unravel_path():
 
         cases = [
             # input                 # expected output
-            ('',                    cwd_full),
-            ('.',                   cwd_full),
-            ('./nonesuch/..',       cwd_full),
+            ('',                    ''),
+            ('.',                   '.'),
 
             ('~',                   tilde_full),
 
-            # Leading / because bare words are unraveled relative to cwd
+            ('$%s' % env_key,       env_val),
             ('/$%s' % env_key,      os.path.join('/', env_val)),
 
             ('~/$%s' % env_key,     os.path.join(tilde_full, env_val)),
-
-            ('/',                   '/'),
-            ('/../',                '/'),
         ]
-
-        platform_specific_cases = [
-            ('/tmp',                '/tmp'),
-            ('/tmp/foo/..',         '/tmp'),
-        ]
-
-        for (input, expected) in platform_specific_cases:
-            # macOS-compatibility
-            if sys.platform.startswith('darwin'):
-                cases.append((input, "/private" + expected))
-            else:
-                cases.append((input, expected))
 
         for (input, expected) in cases:
             actual = _unravel_path(input)
             assert(actual == expected)
+
+
+@patch('os.path.expanduser')  # noqa: C901
+@patch('os.path.expandvars')
+def test_unravel_path_resolvers(expandvars_mock, expanduser_mock):
+    # This test isolates just the behavior of the `resolvers` argument to
+    # _unravel_path. The set of test cases grows rather quickly if you cross
+    # resolver equivalence classes with input equivalence classes, so we'll
+    # just trust that testing each axis independently is sufficient.
+    from jupyter_sigplot.sigplot import _unravel_path
+
+    # Set up scaffolding to record the names of functions, in order, as they
+    # are called.
+    call_list = []
+
+    def reset():
+        call_list[:] = []
+
+    # Note that all functions take a single argument
+    def make_recorder(name):
+        def f(a):
+            call_list.append(name)
+            return a
+        return f
+
+    def recordit(f):
+        r = make_recorder(f.func_name)
+
+        def wrapped(a):
+            r(a)
+            return f(a)
+        wrapped.func_name = f.func_name
+        return wrapped
+
+    expandvars_mock.side_effect = make_recorder('expandvars')
+    expanduser_mock.side_effect = make_recorder('expanduser')
+
+    @recordit
+    def one(p): return p + '1'
+
+    @recordit
+    def two(p): return p + '2'
+
+    @recordit
+    def three(p): return p + '3'
+
+    for resolvers, expected in [
+            ([],                     ''),
+            ([one],                  '1'),
+            ([one, two],             '12'),
+            ([two, one],             '21'),
+            ([one, two, three],      '123'),
+            ([three, two, one, one], '3211'),
+    ]:
+        reset()
+        expected_names = ['expandvars', 'expanduser'] + \
+                         [f.func_name for f in resolvers]
+        actual = _unravel_path('', resolvers)
+        # Ensure that resolvers are called in the right sequence relative to
+        # one another and relative to expandvars/expanduser
+        assert(call_list == expected_names)
+        # Ensure that resolvers are composed (output of rN is input of rN+1)
+        assert(actual == expected)
+
+    # Check that we get an error when resolvers arg is not as expected
+    for resolvers in [
+        3,
+        # 0, Equivalent to resolvers=None, i.e., no resolvers
+        'a string',
+        [3, 0],
+        ['a string'],
+    ]:
+        with pytest.raises(TypeError):
+            _unravel_path('foo.tmp', resolvers)
 
 
 @patch('os.mkdir')
@@ -538,6 +594,78 @@ def test_local_name_for_file_bad_inputs():
             _local_name_for_file(fpath, local_dir)
 
 
+@patch('jupyter_sigplot.sigplot._unravel_path')
+def test_prepare_file_input_resolver(unravel_path_mock):
+    """
+    Ensure that resolvers get passed through from _prepare_file_input to
+    _unravel_path
+    """
+    from jupyter_sigplot.sigplot import _prepare_file_input
+
+    # Needed to avoid a type error internal to _prepare_file_input; value is
+    # unimportant, but type matters
+    unravel_path_mock.return_value = 'bar.tmp'
+
+    def one(f): pass
+
+    fname = 'foo.tmp'
+    for resolvers in [
+        [],
+        [one],
+    ]:
+        unravel_path_mock.reset_mock()
+        _prepare_file_input(fname, '', resolvers)
+        unravel_path_mock.assert_called_once_with(fname, resolvers)
+
+
+def test_instance_level_resolver():
+    from jupyter_sigplot.sigplot import SigPlot
+
+    def to_foo(s):
+        return 'foo'
+
+    # If a single path resolver makes it all the way through the prepare step,
+    # we assume that other tests ensure more complicated cases do, too.
+
+    # Resolver specified in constructor
+    p = SigPlot(path_resolvers=[to_foo])
+    p.overlay_file('baz')
+    assert(p.inputs == ['foo'])
+
+    p = SigPlot('bar', path_resolvers=[to_foo])
+    assert(p.path_resolvers == [to_foo])
+    assert(p.inputs == ['foo'])
+
+    p = SigPlot('bar|baz', path_resolvers=[to_foo])
+    assert(p.inputs == ['foo', 'foo'])
+
+    # Resolver specified after construction
+    p = SigPlot()
+    p.path_resolvers = [to_foo]
+    p.overlay_href('quux')
+    assert(p.path_resolvers == [to_foo])
+    assert(p.inputs == ['foo'])
+
+
+def test_class_level_resolver():
+    from jupyter_sigplot.sigplot import SigPlot
+
+    def to_foo(s):
+        return 'foo'
+
+    SigPlot.path_resolvers = [to_foo]
+
+    # Resolver applied in constructor
+    p = SigPlot('bar.tmp')
+    assert(p.path_resolvers == [to_foo])
+    assert(p.inputs == ['foo'])
+
+    # Resolver applied post constructor
+    p = SigPlot()
+    p.overlay_href('baz|quux.mat')
+    assert(p.inputs == ['foo', 'foo'])
+
+
 def test_split_inputs():
     from jupyter_sigplot.sigplot import _split_inputs
     cases = [
@@ -589,7 +717,7 @@ def test_prepare_href_input(prepare_http_input_mock,
     reset()
     _prepare_href_input('foo.tmp', local_dir)
     prepare_http_input_mock.assert_not_called()
-    prepare_file_input_mock.assert_called_once_with('foo.tmp', local_dir)
+    prepare_file_input_mock.assert_called_once_with('foo.tmp', local_dir, None)
 
     # url only
     reset()
@@ -605,7 +733,7 @@ def test_prepare_href_input(prepare_http_input_mock,
     prepare_http_input_mock.assert_called_once_with(
         'https://www.example.com/bar.tmp',
         local_dir)
-    prepare_file_input_mock.assert_called_once_with('foo.tmp', local_dir)
+    prepare_file_input_mock.assert_called_once_with('foo.tmp', local_dir, None)
 
     # order independence
     reset()
@@ -613,7 +741,7 @@ def test_prepare_href_input(prepare_http_input_mock,
     prepare_http_input_mock.assert_called_once_with(
         'https://www.example.com/bar.tmp',
         local_dir)
-    prepare_file_input_mock.assert_called_once_with('foo.tmp', local_dir)
+    prepare_file_input_mock.assert_called_once_with('foo.tmp', local_dir, None)
 
     # multiple of each
     reset()

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -31,7 +31,8 @@ class EnvironmentVariable(object):
     def __exit__(self, *args):
         """Sets the environment variable back to the way it was before.
         """
-        if self.old_value:
+        # Check against None explicitly so we restore empty strings too
+        if self.old_value is not None:
             os.environ[self.key] = self.old_value
         else:
             del os.environ[self.key]


### PR DESCRIPTION
There are two minor commits at the beginning here that I think are low risk. The real substance is the third commit, which adds a hook for user-specified callables in the pathname resolution chain. The intended use is to support lookup of relative pathnames in auxiliary search paths defined by the execution context.