### PR TITLE
FIX #17: stored notebook's directory to aid client in finding stored file

### DIFF
--- a/example/JupyterSigplot.ipynb
+++ b/example/JupyterSigplot.ipynb
@@ -38,12 +38,14 @@
     "- `overlay_array(data)` - adds an array of numbers to the sigplot's input data\n",
     "- `overlay_href(path)` - adds data from a file to the sigplot\n",
     "- `change_settings(kwargs*)` - changes the options of the sigplot\n",
-    "- `plot(args*)` - displays an interactive sigplot"
+    "- `plot(args*)` - displays an interactive sigplot\n",
+    "\n",
+    "(Note: Changing the kernel's current working directory will affect relative data paths.)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,13 +58,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bbfc31ee2b574e32880468ca64c160e8",
+       "model_id": "7b853f33df5b4d1f94c93d4e29a35f00",
        "version_major": 2,
        "version_minor": 0
       },
@@ -76,12 +78,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bbfc31ee2b574e32880468ca64c160e8",
+       "model_id": "7b853f33df5b4d1f94c93d4e29a35f00",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "U2lnUGxvdChhcnJheV9vYmo9eydvdmVycmlkZXMnOiB7fSwgJ2RhdGEnOiBbMS4wLCAwLjk5OTk1MDAwMDQxNjY2NTMsIDAuOTk5ODAwMDA2NjY2NTc3OCwgMC45OTk1NTAwMzM3NDg5ODc1LCDigKY=\n"
+       "U2lnUGxvdChhcnJheV9vYmo9e3Unb3ZlcnJpZGVzJzoge30sIHUnZGF0YSc6IFsxLjAsIDAuOTk5OTUwMDAwNDE2NjY1MywgMC45OTk4MDAwMDY2NjY1Nzc4LCAwLjk5OTU1MDAzMzc0ODk4NzXigKY=\n"
       ]
      },
      "metadata": {},
@@ -110,13 +112,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "74e70f17b8664b6794efb6fecf84c3f6",
+       "model_id": "fa25fa738a0d4c84a14471efc7668393",
        "version_major": 2,
        "version_minor": 0
       },
@@ -140,13 +142,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fc1ac15dbcb140deba6181f807de4979",
+       "model_id": "0c32cf36fa59471cb306ec190570a7c6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -168,13 +170,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8e25767247564553bfa20f398ec6ba46",
+       "model_id": "c22239be301648afadb7837877fafae9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -189,19 +191,21 @@
    "source": [
     "# once the resource is local,\n",
     "# you can just refer to the filename\n",
+    "# Note: changing the kernel's current working directory will affect\n",
+    "# relative data paths.\n",
     "plot = SigPlot(\"sin.tmp\")\n",
     "plot.plot()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "25bbd2e6b3a84f8fbd18efa0cb94bde4",
+       "model_id": "2f384b8afbaf422aa7ced7622f1b0299",
        "version_major": 2,
        "version_minor": 0
       },
@@ -226,13 +230,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "91691c08163542cf97a09f9b4e750388",
+       "model_id": "1c5e4b1dfcc440bcacdebd130f82864f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -254,13 +258,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "db72a4c1cca44a7d8a36d1589db4515e",
+       "model_id": "689252f476e2493cb82c333a371a69b8",
        "version_major": 2,
        "version_minor": 0
       },
@@ -282,13 +286,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f670d18bb89747599e3f29cd925eada2",
+       "model_id": "a417a42edc464befa98a4c88a9c73313",
        "version_major": 2,
        "version_minor": 0
       },
@@ -312,13 +316,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "44f56a823e53412f8883dc2d3856bfe1",
+       "model_id": "b4096876c013476e9688b4b04067eb82",
        "version_major": 2,
        "version_minor": 0
       },
@@ -340,13 +344,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "03cef7d932914b1b9f97ab0d94e08cbe",
+       "model_id": "2af3b544cf4642a0aee39fc96e4a6b4f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -369,13 +373,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5694466b031342d0b72145bdbdb57a32",
+       "model_id": "7f19160cc3d348ec8e0e4ab38b32f109",
        "version_major": 2,
        "version_minor": 0
       },
@@ -417,7 +421,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/jupyter_sigplot/__init__.py
+++ b/jupyter_sigplot/__init__.py
@@ -3,7 +3,6 @@ from ._version import version_info, __version__
 
 
 def _jupyter_nbextension_paths():
-    # type: () -> List[Dict[str, str]]
     '''
     Exposes the Jupyter Notebook Extension entrypoints
     '''

--- a/jupyter_sigplot/sigplot.py
+++ b/jupyter_sigplot/sigplot.py
@@ -61,12 +61,11 @@ class SigPlot(widgets.DOMWidget):
         self.arrays = []
         # Where to look for data, and where to cache/symlink remote resources
         # that the server or client cannot access directly.
-        #
-        # TODO (sat 2018-11-16): This actually needs to be relative to the
-        # effective root of the notebook server, not just this kernel. See
-        # Github issue #17. I expect that we'll be able to just set
-        # self.data_dir to the notebook server's cwd/root and be good to go.
-        self.data_dir = kwargs.pop('data_dir', '')
+        self.notebook_dir = os.getcwd()
+        self.data_dir = kwargs.pop('data_dir', self.notebook_dir)
+        if not os.path.isabs(self.data_dir):
+            # Need to store absolute path of data directory in case user os.chdir
+            self.data_dir = os.getcwd() + "/" + self.data_dir
 
         if 'path_resolvers' in kwargs:
             # Don't use pop()+default because we don't want to override class-
@@ -148,6 +147,7 @@ class SigPlot(widgets.DOMWidget):
         """
         for pi in _prepare_href_input(fpath,
                                       self.data_dir,
+                                      self.notebook_dir,
                                       self.path_resolvers):
             obj = {
                 "filename": pi,
@@ -182,6 +182,7 @@ class SigPlot(widgets.DOMWidget):
         # consumed it, add to self.inputs here, and trigger self.plot()
         prepared_paths = _prepare_href_input(paths,
                                              self.data_dir,
+                                             self.notebook_dir,
                                              self.path_resolvers)
         self.inputs.extend(prepared_paths)
 
@@ -298,7 +299,7 @@ def _local_name_for_href(url, local_dir):
     return local_path
 
 
-def _prepare_http_input(url, local_dir):
+def _prepare_http_input(url, local_dir, notebook_dir):
     """
     Given a URI, fetch the named resource to a file in <local_dir>, to avoid
     CORS issues.
@@ -306,7 +307,6 @@ def _prepare_http_input(url, local_dir):
     :return: A filename in the local filesystem, under <local_dir>
     """
     _require_dir(local_dir)
-
     local_fname = _local_name_for_href(url, local_dir)
     r = requests.get(url)
     with open(local_fname, 'wb') as f:
@@ -316,7 +316,10 @@ def _prepare_http_input(url, local_dir):
     #
     # The client side of the widget will automatically look for a path
     # relative to <local_dir>
-    return local_fname
+    #
+    # (jrmims 2019-01-24): Added notebook_dir to track the notebook's directory
+    # since that is where the relative path should be based on.
+    return os.path.relpath(local_fname, start=notebook_dir)
 
 
 def _unravel_path(path, resolvers=None):
@@ -369,11 +372,10 @@ def _local_name_for_file(fpath, local_dir):
     else:
         is_local = False
         local_relative_path = os.path.basename(abs_fpath)
-
     return (os.path.join(local_dir, local_relative_path), is_local)
 
 
-def _prepare_file_input(orig_fname, local_dir, resolvers=None):
+def _prepare_file_input(orig_fname, local_dir, notebook_dir, resolvers=None):
     """
     Given an arbitrary filename, determine whether that file is a child of
     <local_dir>. If not, create a symlink under <local_dir> that points to the
@@ -388,15 +390,14 @@ def _prepare_file_input(orig_fname, local_dir, resolvers=None):
     :return: A filename in the local filesystem, under <local_dir>
     """
     input_path = _unravel_path(orig_fname, resolvers)
-
     # TODO (sat 2018-11-07): Handle errors more thoroughly
     # * unable to make local path
     # * symlink already exists, to wrong target
     # * original file does not exist / has bad perms
     _require_dir(local_dir)
 
-    # TODO (sat 2018-11-07): Do the right thing if <local_dir> is absolute
     local_fname, is_local = _local_name_for_file(input_path, local_dir)
+
     if not is_local:
         try:
             # Note that _unravel_path keeps relative names like ../foo.tmp
@@ -407,7 +408,8 @@ def _prepare_file_input(orig_fname, local_dir, resolvers=None):
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
-
+    # Because local_dir is provided as the absolute path, convert back to relative path
+    local_fname = os.path.relpath(local_fname, start=notebook_dir)
     return local_fname
 
 
@@ -427,7 +429,7 @@ def _split_inputs(orig_inputs):
     return inputs
 
 
-def _prepare_href_input(orig_inputs, local_dir, resolvers=None):
+def _prepare_href_input(orig_inputs, local_dir, notebook_dir, resolvers=None):
     """
     Given an input specification containing one or more filesystem paths and
     URIs separated by '|', prepare each one according to its type.
@@ -435,16 +437,15 @@ def _prepare_href_input(orig_inputs, local_dir, resolvers=None):
     :return: A list of filenames in the local filesystem, under <local_dir>
     """
     prepared = []
-
     for oi in _split_inputs(orig_inputs):
         if oi.startswith("http"):
-            pi = _prepare_http_input(oi, local_dir)
+            pi = _prepare_http_input(oi, local_dir, notebook_dir)
         else:
             # TODO (sat 2019-01-08): This `resolvers` argument  feels like a
             # bad factoring, since only one branch uses it; may want to move
             # _prepare_href_input to a class member or else replace with a
             # split+dispatch idiom at the point of call.
-            pi = _prepare_file_input(oi, local_dir, resolvers)
+            pi = _prepare_file_input(oi, local_dir, notebook_dir, resolvers)
         prepared.append(pi)
 
     return prepared

--- a/jupyter_sigplot/sigplot.py
+++ b/jupyter_sigplot/sigplot.py
@@ -66,7 +66,7 @@ class SigPlot(widgets.DOMWidget):
         if not os.path.isabs(self.data_dir):
             # Need to store absolute path of data directory in case user
             # uses os.chdir()
-            self.data_dir = os.getcwd() + "/" + self.data_dir
+            self.data_dir = os.path.join(self.notebook_dir, self.data_dir)
 
         if 'path_resolvers' in kwargs:
             # Don't use pop()+default because we don't want to override class-

--- a/jupyter_sigplot/sigplot.py
+++ b/jupyter_sigplot/sigplot.py
@@ -60,12 +60,9 @@ class SigPlot(widgets.DOMWidget):
         self.hrefs = []
         self.arrays = []
         # Where to look for data, and where to cache/symlink remote resources
-        # that the server or client cannot access directly.
-        #
-        # TODO (sat 2018-11-16): This actually needs to be relative to the
-        # effective root of the notebook server, not just this kernel. See
-        # Github issue #17. I expect that we'll be able to just set
-        # self.data_dir to the notebook server's cwd/root and be good to go.
+        # that the server or client cannot access directly. Note that changing
+        # the kernel's current directory affects data_dir if it is set as a
+        # relative path.
         self.data_dir = kwargs.pop('data_dir', '')
 
         if 'path_resolvers' in kwargs:

--- a/jupyter_sigplot/sigplot.py
+++ b/jupyter_sigplot/sigplot.py
@@ -64,7 +64,8 @@ class SigPlot(widgets.DOMWidget):
         self.notebook_dir = os.getcwd()
         self.data_dir = kwargs.pop('data_dir', self.notebook_dir)
         if not os.path.isabs(self.data_dir):
-            # Need to store absolute path of data directory in case user os.chdir
+            # Need to store absolute path of data directory in case user
+            # uses os.chdir()
             self.data_dir = os.getcwd() + "/" + self.data_dir
 
         if 'path_resolvers' in kwargs:
@@ -408,7 +409,7 @@ def _prepare_file_input(orig_fname, local_dir, notebook_dir, resolvers=None):
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
-    # Because local_dir is provided as the absolute path, convert back to relative path
+    # local_dir is provided as the absolute path, convert back to relative path
     local_fname = os.path.relpath(local_fname, start=notebook_dir)
     return local_fname
 

--- a/test/test_jupyter_sigplot.py
+++ b/test/test_jupyter_sigplot.py
@@ -160,15 +160,16 @@ def test_show_href_file_absolute_already_in_cwd():
 def test_show_href_file_absolute_not_already_there(symlink_mock, mkdir_mock):
     path = "~/foo.tmp"
     plot = SigPlot()
+
     plot.show_href(path, '1D')
     assert mkdir_mock.call_count == 1
-    assert mkdir_mock.call_args[0][0] == os.getcwd()
+    assert mkdir_mock.call_args[0][0] == '.'
 
     assert symlink_mock.call_count == 1
 
     local_path = 'foo.tmp'
     fpath = os.path.expanduser(os.path.expandvars(path))
-    assert symlink_mock.call_args[0] == (fpath, os.path.abspath(local_path))
+    assert symlink_mock.call_args[0] == (fpath, local_path)
 
 
 @patch('os.mkdir')
@@ -179,13 +180,13 @@ def test_show_href_file_relative(symlink_mock, mkdir_mock):
 
     plot.show_href(path, '1D')
     assert mkdir_mock.call_count == 1
-    assert mkdir_mock.call_args[0][0] == os.getcwd()
+    assert mkdir_mock.call_args[0][0] == '.'
 
     assert symlink_mock.call_count == 1
 
     local_path = 'foo.tmp'
     fpath = os.path.expanduser(os.path.expandvars(path))
-    assert symlink_mock.call_args[0] == (fpath, os.path.abspath(local_path))
+    assert symlink_mock.call_args[0] == (fpath, local_path)
 
 
 def test_overlay_href_non_empty_file():
@@ -613,7 +614,7 @@ def test_prepare_file_input_resolver(unravel_path_mock):
         [one],
     ]:
         unravel_path_mock.reset_mock()
-        _prepare_file_input(fname, '', '', resolvers)
+        _prepare_file_input(fname, '', resolvers)
         unravel_path_mock.assert_called_once_with(fname, resolvers)
 
 
@@ -700,7 +701,6 @@ def test_prepare_href_input(prepare_http_input_mock,
 
     # The value is unimportant for this test
     local_dir = None
-    notebook_dir = None
 
     def reset():
         for m in (prepare_file_input_mock,
@@ -709,69 +709,44 @@ def test_prepare_href_input(prepare_http_input_mock,
             m.reset_mock()
 
     # empty input
-    _prepare_href_input('', local_dir, notebook_dir)
+    _prepare_href_input('', local_dir)
     prepare_http_input_mock.assert_not_called()
     prepare_file_input_mock.assert_not_called()
 
     # file only
     reset()
-    _prepare_href_input('foo.tmp', local_dir, notebook_dir)
+    _prepare_href_input('foo.tmp', local_dir)
     prepare_http_input_mock.assert_not_called()
-    prepare_file_input_mock.assert_called_once_with(
-        'foo.tmp',
-        local_dir,
-        notebook_dir,
-        None)
+    prepare_file_input_mock.assert_called_once_with('foo.tmp', local_dir, None)
 
     # url only
     reset()
-    _prepare_href_input(
-        'https://www.example.com/bar.tmp',
-        local_dir,
-        notebook_dir)
+    _prepare_href_input('https://www.example.com/bar.tmp', local_dir)
     prepare_http_input_mock.assert_called_once_with(
         'https://www.example.com/bar.tmp',
-        local_dir,
-        notebook_dir)
+        local_dir)
     prepare_file_input_mock.assert_not_called()
 
     # file and url
     reset()
-    _prepare_href_input(
-        'foo.tmp|https://www.example.com/bar.tmp',
-        local_dir,
-        notebook_dir)
+    _prepare_href_input('foo.tmp|https://www.example.com/bar.tmp', local_dir)
     prepare_http_input_mock.assert_called_once_with(
         'https://www.example.com/bar.tmp',
-        local_dir,
-        notebook_dir)
-    prepare_file_input_mock.assert_called_once_with(
-        'foo.tmp',
-        local_dir,
-        notebook_dir,
-        None)
+        local_dir)
+    prepare_file_input_mock.assert_called_once_with('foo.tmp', local_dir, None)
 
     # order independence
     reset()
-    _prepare_href_input(
-        'https://www.example.com/bar.tmp|foo.tmp',
-        local_dir,
-        notebook_dir)
+    _prepare_href_input('https://www.example.com/bar.tmp|foo.tmp', local_dir)
     prepare_http_input_mock.assert_called_once_with(
         'https://www.example.com/bar.tmp',
-        local_dir,
-        notebook_dir)
-    prepare_file_input_mock.assert_called_once_with(
-        'foo.tmp',
-        local_dir,
-        notebook_dir,
-        None)
+        local_dir)
+    prepare_file_input_mock.assert_called_once_with('foo.tmp', local_dir, None)
 
     # multiple of each
     reset()
     _prepare_href_input(
         'https://www.example.com/bar.tmp| foo.tmp|baz.tmp|http://www.example.com/quux.tmp  | xyzzy.prm',  # noqa: E501
-        local_dir,
-        notebook_dir)
+        local_dir)
     assert prepare_http_input_mock.call_count == 2
     assert prepare_file_input_mock.call_count == 3

--- a/test/test_jupyter_sigplot.py
+++ b/test/test_jupyter_sigplot.py
@@ -717,36 +717,61 @@ def test_prepare_href_input(prepare_http_input_mock,
     reset()
     _prepare_href_input('foo.tmp', local_dir, notebook_dir)
     prepare_http_input_mock.assert_not_called()
-    prepare_file_input_mock.assert_called_once_with('foo.tmp', local_dir, notebook_dir, None)
+    prepare_file_input_mock.assert_called_once_with(
+        'foo.tmp',
+        local_dir,
+        notebook_dir,
+        None)
 
     # url only
     reset()
-    _prepare_href_input('https://www.example.com/bar.tmp', local_dir, notebook_dir)
+    _prepare_href_input(
+        'https://www.example.com/bar.tmp',
+        local_dir,
+        notebook_dir)
     prepare_http_input_mock.assert_called_once_with(
         'https://www.example.com/bar.tmp',
-        local_dir, notebook_dir)
+        local_dir,
+        notebook_dir)
     prepare_file_input_mock.assert_not_called()
 
     # file and url
     reset()
-    _prepare_href_input('foo.tmp|https://www.example.com/bar.tmp', local_dir, notebook_dir)
+    _prepare_href_input(
+        'foo.tmp|https://www.example.com/bar.tmp',
+        local_dir,
+        notebook_dir)
     prepare_http_input_mock.assert_called_once_with(
         'https://www.example.com/bar.tmp',
-        local_dir, notebook_dir)
-    prepare_file_input_mock.assert_called_once_with('foo.tmp', local_dir, notebook_dir, None)
+        local_dir,
+        notebook_dir)
+    prepare_file_input_mock.assert_called_once_with(
+        'foo.tmp',
+        local_dir,
+        notebook_dir,
+        None)
 
     # order independence
     reset()
-    _prepare_href_input('https://www.example.com/bar.tmp|foo.tmp', local_dir, notebook_dir)
+    _prepare_href_input(
+        'https://www.example.com/bar.tmp|foo.tmp',
+        local_dir,
+        notebook_dir)
     prepare_http_input_mock.assert_called_once_with(
         'https://www.example.com/bar.tmp',
-        local_dir, notebook_dir)
-    prepare_file_input_mock.assert_called_once_with('foo.tmp', local_dir, notebook_dir, None)
+        local_dir,
+        notebook_dir)
+    prepare_file_input_mock.assert_called_once_with(
+        'foo.tmp',
+        local_dir,
+        notebook_dir,
+        None)
 
     # multiple of each
     reset()
     _prepare_href_input(
         'https://www.example.com/bar.tmp| foo.tmp|baz.tmp|http://www.example.com/quux.tmp  | xyzzy.prm',  # noqa: E501
-        local_dir, notebook_dir)
+        local_dir,
+        notebook_dir)
     assert prepare_http_input_mock.call_count == 2
     assert prepare_file_input_mock.call_count == 3


### PR DESCRIPTION
I believe I have fixed issue 17 with the understanding that the user will not call os.chdir() before creating a SigPlot object. Doing so breaks the path that is stored as "notebook_dir" on creation.

I've ran through a few different scenarios and not had issues, but please double check my work with existing notebooks.

I removed the TODO [here](https://github.com/LGSInnovations/jupyter-sigplot/compare/master...jrmims:issue_17?expand=1#diff-cde14e61eb0a0fead146831ff9271ba1L398) because I believe I have taken care of it.