### PR TITLE
Update the example notebook to reflect recent changes

### DIFF
--- a/example/JupyterSigplot.ipynb
+++ b/example/JupyterSigplot.ipynb
@@ -12,7 +12,7 @@
     "- Download extension from [GitHub](https://github.com/LGSInnovations/jupyter-sigplot)\n",
     "- Install Python 2.6+ or 3.5+\n",
     "- Install `pip` (usually bundled with Python)\n",
-    "- Install Jupyter using `pip`\n",
+    "- Install Jupyter using `pip` (or install the Anaconda platform, which also includes Jupyter)\n",
     "\n",
     "```\n",
     "pip install jupyter\n",
@@ -31,21 +31,19 @@
     "$ jupyter notebook\n",
     "```\n",
     "\n",
-    "- (Note: you do not need X-MIDAS installed to use  [SigPlot](https://github.com/lgsinnovations/sigplot).)\n",
-    "\n",
     "## SigPlot Usage\n",
-    "- `Sigplot(args*, kwargs*)` - creates a sigplot with each arg as input data and kwargs as options\n",
+    "- `Sigplot(*args, **kwargs)` - creates a sigplot with each arg as input data and kwargs as options\n",
     "- `overlay_array(data)` - adds an array of numbers to the sigplot's input data\n",
-    "- `overlay_href(path)` - adds data from a file to the sigplot\n",
-    "- `change_settings(kwargs*)` - changes the options of the sigplot\n",
-    "- `plot(args*)` - displays an interactive sigplot\n",
+    "- `overlay_href(path)` - adds data from a file or URI to the sigplot\n",
+    "- `change_settings(**kwargs)` - changes the options of the sigplot\n",
+    "- `plot(*args)` - displays an interactive sigplot\n",
     "\n",
     "(Note: Changing the kernel's current working directory will affect relative data paths.)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,111 +56,58 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e2f37b50b47e4717a7d26885cf9837a8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot(options={'noyaxis': True, 'noxaxis': True})"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e2f37b50b47e4717a7d26885cf9837a8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "U2lnUGxvdChhcnJheV9vYmo9e3Unb3ZlcnJpZGVzJzoge30sIHUnZGF0YSc6IFsxLjAsIDAuOTk5OTUwMDAwNDE2NjY1MywgMC45OTk4MDAwMDY2NjY1Nzc4LCAwLjk5OTU1MDAzMzc0ODk4NzXigKY=\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# self-explanatory, but we're instantiating a `SigPlot` object\n",
-    "# and saying do not show the x and y axes.\n",
+    "# Instantiate a `SigPlot` object with keyword arguments to hide the x and y axes.\n",
     "plot = SigPlot(noxaxis=True, noyaxis=True)\n",
     "\n",
-    "# Multiple `overlay_*` calls will layer on top of one-another\n",
+    "# Multiple `overlay_*` calls will layer on top of one another.\n",
     "plot.overlay_array(np.sin(np.arange(0, 20, 0.01)))\n",
     "plot.overlay_array(np.cos(np.arange(0, 20, 0.01)))\n",
     "\n",
-    "# `plot()` is the guy that will actually render the layers\n",
-    "plot.plot()\n",
-    "\n",
-    "# you can change settings after the plot is instantiated,\n",
-    "# so we'll invert the plot colors, add cross-hairs, and show the x axis!\n",
-    "plot.change_settings(xi=True, cross=True, noxaxis=False)\n",
-    "\n",
-    "# ...and replot!\n",
+    "# `plot` is the call that will actually render the layers.\n",
     "plot.plot()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "07873d574c6344dd8d0612337b248b27",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot(options={'noyaxis': False, 'noxaxis': True})"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
+   "source": [
+    "# You can change settings after the plot is instantiated,\n",
+    "# so we'll invert the plot colors, add cross-hairs, and show the x axis!\n",
+    "#\n",
+    "# Note that some settings currently are spelled differently in the constructor\n",
+    "# than in change settings (noxaxis / show_x_axis).\n",
+    "plot.change_settings(invert=True, cross=True, show_x_axis=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "plot = SigPlot(noxaxis=True, noyaxis=False)\n",
     "\n",
-    "# overlay_href() can accept a local Jupyter file or an arbitrary URI;\n",
+    "# `overlay_href` can accept a local Jupyter file or an arbitrary URI;\n",
     "# if it's an http or https URI, it will copy the file locally to\n",
-    "# avoid dealing with cross-origin resource sharing (CORS)\n",
+    "# avoid dealing with cross-origin resource sharing (CORS).\n",
     "plot.overlay_href(\"http://sigplot.lgsinnovations.com/dat/pulse.tmp\")\n",
     "plot.plot()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f31f2d10b39b4729b2adc3c6b9812f58",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# note: you can also instantiate a `SigPlot` object with an array or href too,\n",
-    "# and it will add it as a layer\n",
+    "# You can also instantiate a `SigPlot` object with an array or href. \n",
+    "# It will add the argument as a layer.\n",
     "plot = SigPlot(\"http://sigplot.lgsinnovations.com/dat/sin.tmp\")\n",
     "plot.overlay_href(\"http://sigplot.lgsinnovations.com/dat/pulse.tmp\")\n",
     "plot.plot()"
@@ -170,27 +115,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "47f264b3eeef49fb954bac146fbcef2f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# once the resource is local,\n",
-    "# you can just refer to the filename\n",
+    "# Once a local copy of the the resource has been made,\n",
+    "# you can just refer to the filename.\n",
     "# Note: changing the kernel's current working directory will affect\n",
     "# relative data paths.\n",
     "plot = SigPlot(\"sin.tmp\")\n",
@@ -199,26 +129,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a11244986af14e9784aed2531c16052d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# You can also instantiate the `SigPlot()` with multiple\n",
+    "# You can also instantiate SigPlot with multiple\n",
     "# hrefs or arrays\n",
     "plot = SigPlot(\n",
     "    \"http://sigplot.lgsinnovations.com/dat/sin.tmp\",\n",
@@ -230,170 +145,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "14b932238ff9430b95253a95feccd41c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# penny.prm is a type-2000 file, meaning it's layed out as\n",
-    "# a 2-dimensional matrix, so `plot()` will by default plot each row\n",
-    "# individually in a 1-D plot\n",
+    "# penny.prm is a type-2000 file, meaning it's laid out as\n",
+    "# a 2-dimensional matrix. The default behavior is to plot each row\n",
+    "# individually in a 1-D plot.\n",
     "plot = SigPlot(\"http://sigplot.lgsinnovations.com/dat/penny.prm\")\n",
-    "plot.plot()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9cfc28810dd84f569f318e25e0c34504",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "plot = SigPlot(\"http://sigplot.lgsinnovations.com/dat/penny.prm\")\n",
-    "\n",
-    "# if we specifically tell it to `plot('2D')`, it will plot it as\n",
-    "# a heatmap/raster.\n",
-    "plot.plot(\"2D\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9dd86f0481bc40dcbfa448d096804d0a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "plot = SigPlot()\n",
-    "\n",
-    "# we can also force SigPlot to plot 1-dimensional arrays\n",
-    "# as a heatmap/raster with `plot('2D') and setting `subsize`\n",
-    "# to how many elements should be in each row\n",
-    "plot.overlay_array([1,2,3,2,3,4,1,2,3])\n",
-    "plot.plot(\"2D\", subsize=3)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "077033f8a4f649959a99271a6ad672f0",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "plot = SigPlot()\n",
-    "plot.overlay_array([1,2,3,2,3,4,1,2,3])\n",
-    "\n",
-    "# note how changing subsize changes the output\n",
-    "plot.plot(\"2D\", subsize=5)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "15216b902bed48818bb8a223392185de",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "plot = SigPlot()\n",
-    "\n",
-    "# alternatively, you can just pass a 2-dimensional array/list\n",
-    "# and as long as \"2D\" is passed, it will plot it correctly\n",
-    "plot.overlay_array([[1,2,3],[2,3,4],[1,2,3]])\n",
-    "plot.plot(\"2D\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fe79765158b14c7bb36c09bb708760cb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# also, hrefs can be '|'-delimited\n",
-    "plot = SigPlot('sin.tmp|pulse.tmp')\n",
     "plot.plot()"
    ]
   },
@@ -402,7 +161,65 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "plot = SigPlot(\"http://sigplot.lgsinnovations.com/dat/penny.prm\")\n",
+    "\n",
+    "# If we specifically ask for a 2D plot, we will get a heatmap/raster.\n",
+    "plot.plot(\"2D\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot = SigPlot()\n",
+    "\n",
+    "# We can also force SigPlot to plot 1-dimensional arrays\n",
+    "# as a heatmap/raster with `plot('2D') by setting `subsize`\n",
+    "# to how many elements should be in each row.\n",
+    "plot.overlay_array([1,2,3,2,3,4,1,2,3], subsize=3)\n",
+    "plot.plot(\"2D\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot = SigPlot()\n",
+    "plot.overlay_array([1,2,3,2,3,4,1,2,3], subsize=5)\n",
+    "\n",
+    "# Note how changing subsize changes the output.\n",
+    "plot.plot(\"2D\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot = SigPlot()\n",
+    "\n",
+    "# Alternatively, you can just pass a 2-dimensional array/list\n",
+    "# and the subsize will be inferred from the data for 2D plots.\n",
+    "plot.overlay_array([[1,2,3],[2,3,4],[1,2,3]])\n",
+    "plot.plot(\"2D\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Multiple arguments can be '|'-delimited in a single string as well\n",
+    "plot = SigPlot('sin.tmp|pulse.tmp')\n",
+    "plot.plot()"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
The main thing here is reflecting a change in when you specify `subsize`. It's now part of `overlay_array`, as in the Javascript version, rather than `plot`. 

Changed some language here and there to clarify.

Because saved notebooks don't currently include rendered plot images, I also saved a "clean" version of the notebook with no executed cells. I like to keep `.ipynb` files in this format to make future diffs easier.

As always, let me know if there's anything you'd like to see done differently.