### PR TITLE
Thin-wrapper refactor

### DIFF
--- a/example/JupyterSigplot.ipynb
+++ b/example/JupyterSigplot.ipynb
@@ -33,7 +33,7 @@
     "\n",
     "- (Note: you do not need X-MIDAS installed to use  [SigPlot](https://github.com/lgsinnovations/sigplot).)\n",
     "\n",
-    "## SigPlot Usage\n",
+    "## sigplot.Plot Usage\n",
     "- `Sigplot(args*, kwargs*)` - creates a sigplot with each arg as input data and kwargs as options\n",
     "- `overlay_array(data)` - adds an array of numbers to the sigplot's input data\n",
     "- `overlay_href(path)` - adds data from a file to the sigplot\n",
@@ -45,12 +45,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The only import you _need_ for plotting is `jupyter_sigplot.sigplot.SigPlot`.\n",
-    "from jupyter_sigplot.sigplot import SigPlot\n",
+    "# The only import you _need_ for plotting is `jupyter_sigplot.sigplot.Plot`.\n",
+    "from jupyter_sigplot.sigplot import Plot\n",
     "\n",
     "# We'll import `numpy` too to show how to plot a `numpy` array.\n",
     "import numpy as np"
@@ -58,196 +58,85 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e2f37b50b47e4717a7d26885cf9837a8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot(options={'noyaxis': True, 'noxaxis': True})"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e2f37b50b47e4717a7d26885cf9837a8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "U2lnUGxvdChhcnJheV9vYmo9e3Unb3ZlcnJpZGVzJzoge30sIHUnZGF0YSc6IFsxLjAsIDAuOTk5OTUwMDAwNDE2NjY1MywgMC45OTk4MDAwMDY2NjY1Nzc4LCAwLjk5OTU1MDAzMzc0ODk4NzXigKY=\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# self-explanatory, but we're instantiating a `SigPlot` object\n",
+    "# self-explanatory, but we're instantiating a `jupyter_sigplot.sigplot.Plot` object\n",
     "# and saying do not show the x and y axes.\n",
-    "plot = SigPlot(noxaxis=True, noyaxis=True)\n",
+    "plot = Plot(noxaxis=True, noyaxis=True)\n",
     "\n",
     "# Multiple `overlay_*` calls will layer on top of one-another\n",
-    "plot.overlay_array(np.sin(np.arange(0, 20, 0.01)))\n",
-    "plot.overlay_array(np.cos(np.arange(0, 20, 0.01)))\n",
-    "\n",
-    "# `plot()` is the guy that will actually render the layers\n",
-    "plot.plot()\n",
+    "plot.overlay_array([1,2,3])\n",
+    "plot.overlay_array([3,2,1])\n",
+    "# plot.overlay_array(np.cos(np.arange(0, 20, 0.01)))\n",
     "\n",
     "# you can change settings after the plot is instantiated,\n",
     "# so we'll invert the plot colors, add cross-hairs, and show the x axis!\n",
-    "plot.change_settings(xi=True, cross=True, noxaxis=False)\n",
-    "\n",
-    "# ...and replot!\n",
-    "plot.plot()"
+    "# plot.change_settings(xi=True, cross=True, noxaxis=False)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "07873d574c6344dd8d0612337b248b27",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot(options={'noyaxis': False, 'noxaxis': True})"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "plot = SigPlot(noxaxis=True, noyaxis=False)\n",
+    "# self-explanatory, but we're instantiating a `SigPlot` object\n",
+    "# and saying do not show the x and y axes.\n",
+    "plot = Plot(noxaxis=True, noyaxis=True)\n",
+    "\n",
+    "# Multiple `overlay_*` calls will layer on top of one-another\n",
+    "x = np.arange(0, 200e3, 100)\n",
+    "plot.overlay_array(np.sin(x))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot = Plot(noxaxis=True, noyaxis=False)\n",
     "\n",
     "# overlay_href() can accept a local Jupyter file or an arbitrary URI;\n",
     "# if it's an http or https URI, it will copy the file locally to\n",
     "# avoid dealing with cross-origin resource sharing (CORS)\n",
-    "plot.overlay_href(\"http://sigplot.lgsinnovations.com/dat/pulse.tmp\")\n",
-    "plot.plot()"
+    "plot.overlay_href(\"http://sigplot.lgsinnovations.com/dat/pulse.tmp\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f31f2d10b39b4729b2adc3c6b9812f58",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# note: you can also instantiate a `SigPlot` object with an array or href too,\n",
-    "# and it will add it as a layer\n",
-    "plot = SigPlot(\"http://sigplot.lgsinnovations.com/dat/sin.tmp\")\n",
-    "plot.overlay_href(\"http://sigplot.lgsinnovations.com/dat/pulse.tmp\")\n",
-    "plot.plot()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "47f264b3eeef49fb954bac146fbcef2f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# once the resource is local,\n",
     "# you can just refer to the filename\n",
     "# Note: changing the kernel's current working directory will affect\n",
     "# relative data paths.\n",
-    "plot = SigPlot(\"sin.tmp\")\n",
-    "plot.plot()"
+    "plot.overlay_href(\"sin.tmp\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a11244986af14e9784aed2531c16052d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# You can also instantiate the `SigPlot()` with multiple\n",
     "# hrefs or arrays\n",
-    "plot = SigPlot(\n",
-    "    \"http://sigplot.lgsinnovations.com/dat/sin.tmp\",\n",
-    "    \"http://sigplot.lgsinnovations.com/dat/pulse.tmp\",\n",
-    "    np.arange(0, 4, .01)\n",
-    ")\n",
-    "plot.plot()"
+    "plot = Plot()\n",
+    "plot.overlay_href(\"http://sigplot.lgsinnovations.com/dat/sin.tmp\")\n",
+    "plot.overlay_href(\"http://sigplot.lgsinnovations.com/dat/pulse.tmp\")\n",
+    "plot.overlay_href(np.arange(0, 4, .01))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "14b932238ff9430b95253a95feccd41c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# penny.prm is a type-2000 file, meaning it's layed out as\n",
     "# a 2-dimensional matrix, so `plot()` will by default plot each row\n",
@@ -258,24 +147,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9cfc28810dd84f569f318e25e0c34504",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "plot = SigPlot(\"http://sigplot.lgsinnovations.com/dat/penny.prm\")\n",
     "\n",
@@ -286,24 +160,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9dd86f0481bc40dcbfa448d096804d0a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "plot = SigPlot()\n",
     "\n",
@@ -316,24 +175,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "077033f8a4f649959a99271a6ad672f0",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "plot = SigPlot()\n",
     "plot.overlay_array([1,2,3,2,3,4,1,2,3])\n",
@@ -344,24 +188,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "15216b902bed48818bb8a223392185de",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "plot = SigPlot()\n",
     "\n",
@@ -373,24 +202,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fe79765158b14c7bb36c09bb708760cb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "SigPlot()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# also, hrefs can be '|'-delimited\n",
     "plot = SigPlot('sin.tmp|pulse.tmp')\n",

--- a/example/JupyterSigplot.ipynb
+++ b/example/JupyterSigplot.ipynb
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,44 +58,105 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "92657b9f9c624fbb93e3c3c303981c1a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Plot(plot_options={'noyaxis': True, 'xi': True, 'noxaxis': True})"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# self-explanatory, but we're instantiating a `jupyter_sigplot.sigplot.Plot` object\n",
     "# and saying do not show the x and y axes.\n",
-    "plot = Plot(noxaxis=True, noyaxis=True)\n",
+    "plot = Plot(noxaxis=True, noyaxis=True, xi=True)\n",
     "\n",
     "# Multiple `overlay_*` calls will layer on top of one-another\n",
-    "plot.overlay_array([1,2,3])\n",
-    "plot.overlay_array([3,2,1])\n",
-    "# plot.overlay_array(np.cos(np.arange(0, 20, 0.01)))\n",
-    "\n",
-    "# you can change settings after the plot is instantiated,\n",
-    "# so we'll invert the plot colors, add cross-hairs, and show the x axis!\n",
-    "# plot.change_settings(xi=True, cross=True, noxaxis=False)"
+    "plot.overlay_array((1,2,3))\n",
+    "plot.overlay_array([3,2,1])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
+    "# you can change settings after the plot is instantiated,\n",
+    "# so we'll add cross-hairs and show the x axis!\n",
+    "plot.change_settings({'cross': True, 'show_x_axis': True})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "56b3afafe24649e4866b0ffcd759c2c9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Plot(plot_options={'noyaxis': True, 'noxaxis': True})"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 715 ms, sys: 330 ms, total: 1.05 s\n",
+      "Wall time: 1.45 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
     "# self-explanatory, but we're instantiating a `SigPlot` object\n",
     "# and saying do not show the x and y axes.\n",
     "plot = Plot(noxaxis=True, noyaxis=True)\n",
     "\n",
     "# Multiple `overlay_*` calls will layer on top of one-another\n",
-    "x = np.arange(0, 200e3, 100)\n",
+    "x = np.arange(0, 200e3, .01)\n",
     "plot.overlay_array(np.sin(x))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "207508d616bf4dd49dbf210e8dcdbdde",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Plot(plot_options={'noyaxis': False, 'noxaxis': True})"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "plot = Plot(noxaxis=True, noyaxis=False)\n",
     "\n",
@@ -107,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,100 +176,174 @@
     "# you can just refer to the filename\n",
     "# Note: changing the kernel's current working directory will affect\n",
     "# relative data paths.\n",
+    "# Note: Running this will affect the previous cell's plot\n",
     "plot.overlay_href(\"sin.tmp\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c7714b038471455d8a08787ade665a28",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Plot()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "# You can also instantiate the `SigPlot()` with multiple\n",
-    "# hrefs or arrays\n",
+    "# You can also plot mixed-types (i.e., hrefs and arrays)\n",
     "plot = Plot()\n",
     "plot.overlay_href(\"http://sigplot.lgsinnovations.com/dat/sin.tmp\")\n",
     "plot.overlay_href(\"http://sigplot.lgsinnovations.com/dat/pulse.tmp\")\n",
-    "plot.overlay_href(np.arange(0, 4, .01))"
+    "plot.overlay_array(np.arange(0, 4, .01))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7c97e655df344ceea1c9b5f66ef3bb07",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Plot()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# penny.prm is a type-2000 file, meaning it's layed out as\n",
     "# a 2-dimensional matrix, so `plot()` will by default plot each row\n",
     "# individually in a 1-D plot\n",
-    "plot = SigPlot(\"http://sigplot.lgsinnovations.com/dat/penny.prm\")\n",
-    "plot.plot()"
+    "plot = Plot()\n",
+    "plot.overlay_href(\"http://sigplot.lgsinnovations.com/dat/penny.prm\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ccd018ceb90a4fe9a76a163b18e44f0e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Plot()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "plot = SigPlot(\"http://sigplot.lgsinnovations.com/dat/penny.prm\")\n",
-    "\n",
-    "# if we specifically tell it to `plot('2D')`, it will plot it as\n",
-    "# a heatmap/raster.\n",
-    "plot.plot(\"2D\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot = SigPlot()\n",
+    "plot = Plot()\n",
     "\n",
     "# we can also force SigPlot to plot 1-dimensional arrays\n",
-    "# as a heatmap/raster with `plot('2D') and setting `subsize`\n",
-    "# to how many elements should be in each row\n",
-    "plot.overlay_array([1,2,3,2,3,4,1,2,3])\n",
-    "plot.plot(\"2D\", subsize=3)"
+    "# as a heatmap/raster setting `subsize` to how many\n",
+    "# elements should be in each row\n",
+    "plot.overlay_array([1,2,3,2,3,4,1,2,3], {'subsize': 3})"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b298732306e444f0bb68efb9f5687f3c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Plot()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "plot = SigPlot()\n",
-    "plot.overlay_array([1,2,3,2,3,4,1,2,3])\n",
-    "\n",
-    "# note how changing subsize changes the output\n",
-    "plot.plot(\"2D\", subsize=5)"
+    "plot = Plot()\n",
+    "plot.overlay_array([1,2,3,2,3,4,1,2,3], {'subsize': 5})"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6b3e6c63017e4a72974c69a79f723564",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Plot()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "plot = SigPlot()\n",
+    "plot = Plot()\n",
     "\n",
     "# alternatively, you can just pass a 2-dimensional array/list\n",
-    "# and as long as \"2D\" is passed, it will plot it correctly\n",
-    "plot.overlay_array([[1,2,3],[2,3,4],[1,2,3]])\n",
-    "plot.plot(\"2D\")"
+    "# and as long as \"subsize\" is passed, it will plot it correctly\n",
+    "plot.overlay_array([[1,2,3],[2,3,4],[1,2,3]], {'subsize': 3})"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "260fd8b8edca462e95066c04a1e2523a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Plot()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "# also, hrefs can be '|'-delimited\n",
-    "plot = SigPlot('sin.tmp|pulse.tmp')\n",
-    "plot.plot()"
+    "plot = Plot()\n",
+    "\n",
+    "# you can also specify multiple files using '|' as\n",
+    "# the delimiter\n",
+    "plot.overlay_href('pulse.tmp|sin.tmp')"
    ]
   },
   {

--- a/jupyter_sigplot/sigplot.py
+++ b/jupyter_sigplot/sigplot.py
@@ -164,10 +164,14 @@ class Plot(widgets.DOMWidget):
             )
             for href in href_list:
                 arguments[0] = href
+
                 # cause the sync to happen
+                # TODO: Figure out why the list comp works
+                #       but passing `arguments` doesn't;
+                #       perhaps it's an addressing issue?
                 self.sync_command_and_arguments({
                     "command": command,
-                    "arguments": arguments,
+                    "arguments": [arg for arg in arguments],
                 })
         else:
             # cause the sync to happen
@@ -177,6 +181,13 @@ class Plot(widgets.DOMWidget):
             })
 
     def sync_command_and_arguments(self, command_and_arguments):
+        """
+
+        :param command_and_arguments:
+        :type command_and_arguments: dict
+        :return:
+        """
+        print(command_and_arguments)
         self.command_and_arguments = command_and_arguments
 
 

--- a/jupyter_sigplot/sigplot.py
+++ b/jupyter_sigplot/sigplot.py
@@ -4,54 +4,58 @@ from __future__ import (
     print_function,
     unicode_literals,
 )
+
 import errno
 import os
 import sys
 
-import numpy as np
-
 import ipywidgets as widgets
+import numpy as np
+import requests
 from traitlets import (
     Unicode,
     Bool,
     Dict,
-    List,
+    Float,
 )
 
-import requests
+from ._version import __version__ as version_string
 
-from IPython.display import (
-    display,
-    clear_output,
-)
+from IPython.display import display
 
 _py3k = sys.version_info[0] == 3
 if _py3k:
     StringType = (str, bytes)
 else:
-    StringType = (basestring, )
+    StringType = (basestring,)
 
 
-class SigPlot(widgets.DOMWidget):
-    _view_module_version = Unicode('0.1.0')
+class Plot(widgets.DOMWidget):
+    """Name and version information required by widgets"""
+    _view_module_version = Unicode(version_string)
     _view_name = Unicode('SigPlotView').tag(sync=True)
     _model_name = Unicode('SigPlotModel').tag(sync=True)
     _view_module = Unicode('jupyter_sigplot').tag(sync=True)
     _model_module = Unicode('jupyter_sigplot').tag(sync=True)
-    href_obj = Dict().tag(sync=True)
-    array_obj = Dict().tag(sync=True)
+
+    """The command and arguments that will get sent"""
+    command_and_arguments = Dict().tag(sync=True)
+
+    """The plot_options dictionary in the JS
+    sigplot.Plot(dom_element, plot_options)"""
+    plot_options = Dict().tag(sync=True)
+
+    """Progress information for the client"""
+    progress = Float().tag(sync=True)
     done = Bool(False).tag(sync=True)
-    options = Dict().tag(sync=True)
-    oldArrays = List().tag(sync=True)
-    oldHrefs = List().tag(sync=True)
-    # Sequence of callables used by _prepare_file_input to resolve relative
-    # pathnames
+
+    """Sequence of callables used by ``_prepare_file_input``
+    to resolve relative pathnames"""
     path_resolvers = []
 
     def __init__(self, *args, **kwargs):
-        self.inputs = []
-        self.hrefs = []
-        self.arrays = []
+        super(Plot, self).__init__(**kwargs)
+
         # Where to look for data, and where to cache/symlink remote resources
         # that the server or client cannot access directly. Note that changing
         # the kernel's current directory affects data_dir if it is set as a
@@ -67,185 +71,140 @@ class SigPlot(widgets.DOMWidget):
             # resolvers per Python semantics.
             self.path_resolvers = kwargs.pop('path_resolvers')
 
-        # Whatever's left is meant for the client half of the widget
-        self.options = kwargs
-        for arg in args:
-            if isinstance(arg, StringType):
-                self.overlay_href(arg)
-            else:
-                self.overlay_array(arg)
-        super(SigPlot, self).__init__(**kwargs)
+        # Whatever's left is meant for sigplot.js's ``sigplot.Plot``
+        self.plot_options = kwargs
 
-    def change_settings(self, **kwargs):
-        new_options = {}
-        new_options.update(self.options)
-        new_options.update(kwargs)
-        self.options = new_options
+        display(self)
 
-    def show_array(self, data, overrides=None, layer_type="1D", subsize=None):
-        array_obj = _prepare_array_input(data, overrides, layer_type, subsize)
-        self._show_array_internal(array_obj)
+    def __getattr__(self, attr):
+        """Enables a "thin-wrapper" around sigplot.Plot (JS)
+        methods
 
-    def _show_array_internal(self, array_obj):
-        if array_obj in self.arrays:
-            return
-        else:
-            self.array_obj = array_obj
-            self.arrays.append(self.array_obj)
-            self.oldArrays = self.arrays
+        Note: ``__getattr__`` is only called if ``attr`` is not
+        an attribute of ``self``
 
-    def overlay_array(self, data, overrides=None,
-                      layer_type="1D", subsize=None):
-        array_obj = _prepare_array_input(data, overrides, layer_type, subsize)
-        self.inputs.append(array_obj)
+        :param attr: An attribute or method
+        :type attr: str
 
-    def show_href(self, fpath, layer_type):  # noqa: C901
+        :return: A function wrapper around ``self.send_command``
+        :rtype: function
+
+        :raises AttributeError: if ``attr`` is not an attribute of
+                                ``self`` or in ``available_commands``
         """
-        Plot a local file or URL with SigPlot. Any resource that
-        cannot be reached directly by the Jupyter server will first
-        be copied or symlinked into a subdirectory of the Jupyter
-        server's working directory.
+        if attr in self.available_commands:
+            # if it doesn't have the attribute,
+            # but ``attr`` exists as sigplot.Plot methods
+            # that we've whitelisted in ``self.available_commands``,
+            # send that command (``attr``) and the arguments
+            # provded to the client to handle (via ``send_command``)
+            def wrapper(*args, **kwargs):
+                command = attr
+                arguments = args
+                self.send_command(command, list(arguments), **kwargs)
+        else:
+            # if ``attr`` is not an attribute of ``self``
+            # AND does not exist on the client, throw the standard
+            # ``AttributeError``
+            raise AttributeError(attr)
+        return wrapper
 
-        :param fpath: File-path to bluefile or matfile. Forms accepted:
-                      - Filesystem paths, e.g., /data/foo.tmp, ../foo.tmp
-                        Environment variables and ~ are expanded:
-                        - $HOME/foo.tmp
-                        - ~/foo.tmp
-                      - URLs, e.g., http://example.com/foo.tmp
-        :type fpath: str
+    @property
+    def available_commands(self):
+        """Available commands from Sigplot.js that Jupyter-SigPlot can call"""
+        return [
+            'change_settings',
+            'overlay_href',
+            'overlay_array',
+        ]
 
-        :param layer_type: either '1D' or '2D'
-        :type layer_type: str
+    def send_command(self, command, arguments, **_):
+        """Sends the Notebook client (JS) the SigPlot.js
+        command and relevant arguments.
+
+        :param command: Command for the ``sigplot.Plot`` JS
+                        object to run
+        :type command: str
+
+        :param arguments: The tuple of the positional arguments and
+                          keyword arguments for SigPlot to run
+        :type arguments: list(Any)
 
         :Example:
-        >>> plot = SigPlot()
-        >>> display(plot)
-        >>> plot.show_href('foo.tmp', layer_type='2D')
+        >>> from jupyter_sigplot.sigplot import Plot
+        >>> plt = Plot()
+        >>> plt.send_command('overlay_href', ['foo.tmp'])
         """
-        for pi in _prepare_href_input(fpath,
-                                      self.data_dir,
-                                      self.path_resolvers):
-            href_obj = {
-                "filename": pi,
-                "layerType": layer_type,
-            }
-            self._show_href_internal(href_obj)
+        # lower the command, just so we're normalized
+        command = command.lower()
 
-    def _show_href_internal(self, href_obj):  # noqa: C901
-        """
-        Common internal function to actually trigger a client-side plot.
-
-        :param href_obj: Dictionary describing what to plot. Interpreted
-                         by the client. Created by user-facing functions
-                         like overlay_href and show_href.
-        :type href_obj: dict
-        """
-        # The change listener on the client will cheerfully re-plot a layer
-        # unless we're careful
-        if href_obj in self.hrefs:
-            return
-
-        self.href_obj = href_obj
-        self.hrefs.append(self.href_obj)
-        self.oldHrefs = self.hrefs
-
-    def overlay_href(self, paths):
-        # TODO (sat 2018-11-08): This does not trigger a plot update like
-        # show_href does. Seems like a recipe for confusion. Should probably
-        # only add to self.inputs if we're not yet rendered, and otherwise
-        # jump right to _show_href_internal; or clear self.inputs after we've
-        # consumed it, add to self.inputs here, and trigger self.plot()
-        prepared_paths = _prepare_href_input(paths,
-                                             self.data_dir,
-                                             self.path_resolvers)
-        self.inputs.extend(prepared_paths)
-
-    def plot(self, layer_type=None):
-        try:
-            display(self)
-            for arg in self.inputs:
-                if isinstance(arg, dict):
-                    if 'data' in arg.keys():
-                        self._show_array_internal({
-                            "data": arg['data'],
-                            "overrides": arg['overrides'],
-                            "layerType": arg['layerType'],
-                            })
-                elif isinstance(arg, StringType):
-                    if layer_type is None:
-                        layer_type = "1D"
-                    self._show_href_internal({
-                        "filename": arg,
-                        # TODO (sat 2018-11-09): I think we should specify
-                        # layer type in overlay_*, allowing each resource to
-                        # have its own layer type. Need to reason about
-                        # multiple 2D layers, though.
-                        "layerType": layer_type,
-                    })
-                else:
-                    raise ValueError("Unknown input type")
-            self.done = True
-        except Exception:
-            clear_output()
-            raise
-
-    def overlay_file(self, path):
-        if not isinstance(path, StringType):
-            raise TypeError(
-                "``path`` must be a string or ``Path`` (Python 3) type"
+        # we need to convert the array argument to numpy arrays
+        if command == 'overlay_array':
+            array = np.array(arguments[0])
+            # make sure np.dtype is something sigplot can plot
+            if not np.issubdtype(array.dtype, np.number):
+                raise TypeError(
+                    'Array passed to overlay_array must be numeric type'
+                )
+            arguments[0] = memoryview(array.astype(np.float32))
+            # cause the sync to happen
+            self.sync_command_and_arguments({
+                "command": command,
+                "arguments": arguments,
+            })
+        elif command == 'overlay_href':
+            # we still need to download the hrefs locally
+            # to avoid CORS
+            href = arguments[0]
+            href_list = _prepare_href_input(
+                href,
+                self.data_dir,
+                self.progress,
+                self.path_resolvers
             )
-        self.overlay_href(path)
+            for href in href_list:
+                arguments[0] = href
+                # cause the sync to happen
+                self.sync_command_and_arguments({
+                    "command": command,
+                    "arguments": arguments,
+                })
+        else:
+            # cause the sync to happen
+            self.sync_command_and_arguments({
+                "command": command,
+                "arguments": arguments,
+            })
+
+    def sync_command_and_arguments(self, command_and_arguments):
+        self.command_and_arguments = command_and_arguments
+
 
 # End of class SigPlot
 ###########################################################################
 
 
-def _prepare_array_input(data, overrides, layer_type, subsize):
-    if not isinstance(data, (list, tuple, np.ndarray)):
-        # TODO (ddw/sat 20190419) we need a stronger check.  What if it's an
-        # array of strings?  Consider ['foo', sys], which will pass np.array()
-        # but not convert to JSON, nor be plottable
-        raise TypeError("Data need to be list, tuple, or ndarray")
-
-    data = np.array(data)
-
-    if len(data.shape) > 2:
-        raise ValueError(
-                'SigPlot only supports 1- and 2-dimensional inputs (got %r)' %
-                (data.shape,))
-
-    new_overrides = {}
-    if overrides:
-        if not isinstance(overrides, dict):
-            raise TypeError(
-                    'Overrides should be a dictionary (got %r)' %
-                    overrides)
-        new_overrides.update(overrides)
-
-    if layer_type not in ("1D", "2D"):
-        # Guess layer_type from data
-        if len(data.shape) == 2:
-            layer_type = "2D"
-        else:
-            layer_type = "1D"
-
-    if layer_type == "2D" and not subsize:
-        subsize = data.shape[-1]
-
-    if subsize:
-        new_overrides["subsize"] = subsize
-
-    data = data.flatten().tolist()
-    array_obj = {
-        "data": data,
-        "overrides": new_overrides,
-        "layerType": layer_type,
-    }
-
-    return array_obj
-
-
 def _require_dir(d):
+    """Creates the path ``d`` similar to ``mkdir -p``
+
+    :param d: Path to create
+    :type d: Union[str, Path]
+
+    :raises: OSError if an error occurs (aside from
+             the path already existing)
+
+    :Examples:
+    >>> from jupyter_sigplot.sigplot import _require_dir
+    >>> import os
+    >>> import shutil
+    >>> path = '/tmp/foo/bar/baz/1/2/3'
+    >>> _require_dir(path)
+    >>> os.path.exists(path)
+    True
+    >>> shutil.rmtree('/tmp/foo')
+    >>> os.path.exists(path)
+    False
+    """
     if d == '':
         # makedirs fails on ''
         d = '.'
@@ -258,13 +217,20 @@ def _require_dir(d):
 
 
 def _local_name_for_href(url, local_dir):
-    """
-    Generate a name for the given url under directory <local_dir>
+    """Generate a name for the given url under directory ``local_dir``
 
-    :return: A path under <local_dir> suitable for storing the contents
-             of <url>
+    :param url: URL that we'll be downloading to some local directory
+                ``local_dir``
+    :type url: str
 
-    .. note:: Different <url> values may map to the same local path
+    :param local_dir: Local directory where URL
+    :type local_dir: str
+
+    :return: A path under ``local_dir`` suitable for storing the contents
+             of ``url``
+    :rtype: str or Path
+
+    .. note:: Different ``url`` values may map to the same local path
     """
     # This function has no side effects, unlike its primary caller,
     # _prepare_http_input . The goal is to make testing easier.
@@ -292,108 +258,168 @@ def _local_name_for_href(url, local_dir):
     return local_path
 
 
-def _prepare_http_input(url, local_dir):
-    """
-    Given a URI, fetch the named resource to a file in <local_dir>, to avoid
-    CORS issues.
+def _prepare_http_input(url, local_dir, progress=None):
+    """Given a URI, fetch the named resource to a file in ``local_dir``,
+    to avoid CORS issues.
+
+    :param url: URL that we'll be downloading to some local directory
+                ``local_dir``
+    :type url: str
+
+    :param local_dir: Local directory to where URL will be downloaded
+    :type local_dir: str
+
+    :param progress: Progress traitlet that will sync with the client
+    :type progress: Optional[traitlets.Float]
 
     :return: A filename in the local filesystem, under <local_dir>
     """
     _require_dir(local_dir)
 
+    # get where the ``url`` will be downloaded to under ``local_dir``
     local_fname = _local_name_for_href(url, local_dir)
-    r = requests.get(url)
+
+    # `stream=True` lets us stream over the response
+    r = requests.get(url, stream=True)
+
+    # get the total file size
+    total_size = int(r.headers.get('content-length', 0))
+
+    # we'll want to iterate over the file by chunks
+    block_size = 1024
+
+    # how much we've written locally (kernel-side)
+    wrote = 0
+
+    # "stream" the remote asset to ``local_file``
     with open(local_fname, 'wb') as f:
-        f.write(r.content)
-    # TODO (sat 2018-11-07): Make sure we do the right thing if <local_dir>
-    # is an absolute path, doesn't exist, etc.
+        for data in r.iter_content(block_size):
+            # keep track of how much we've written
+            f.write(data)
+            wrote += len(data)
+
+            # update the ``progress`` traitlet, which
+            # we will handle on the client-side in some loading
+            # notification (e.g., loading bar via tqdm?, spinny wheel, etc.)
+            if progress is not None:
+                progress = wrote / total_size
+
+    # TODO: Make sure we do the right thing if ``local_dir`` is an
+    #       absolute path, doesn't exist, etc.
     #
     # The client side of the widget will automatically look for a path
-    # relative to <local_dir>
+    # relative to ``local_dir``
     return local_fname
 
 
 def _unravel_path(path, resolvers=None):
+    """Expand user directories and environment variables in ``path``,
+    then run through callables in ``resolvers``. Does NOT call
+    ``realpath`` / ``abspath`` unless that happens to be in ``resolvers``.
+
+    :param path: Path to be unraveled
+    :type path: str or Path
+
+    :param resolvers: Optional list of functions to be applied to ``path``,
+                      e.g., ``os.path.abspath`` or ``os.path.realpath``
+    :type resolvers: Optional[List[function]]
+
+    :return: The unraveled path
+    :rtype: str
+
+    :Example:
+    >>> from jupyter_sigplot.sigplot import _unravel_path
+    >>>
     """
-    Expand user directories and environment variables in <path>, then run
-    through callables in <resolvers>. Does NOT call realpath / abspath unless
-    that happens to be in <resolvers>.
-    """
-    import os.path as p
-    unraveled = p.expanduser(p.expandvars(path))
+    unraveled = os.path.expanduser(os.path.expandvars(path))
     if resolvers:
         for f in resolvers:
             unraveled = f(unraveled)
     return unraveled
 
 
-def _local_name_for_file(fpath, local_dir):
-    """
-    Generate a name for the given a file path under <local_dir> . Expects
-    arguments to already be unraveled.
+def _local_name_for_file(file_path, local_dir):
+    """Generate a name for the given file path under ``local_dir``.
+
+    :param file_path: File that will be renamed and placed under ``local_dir``
+    :type file_path: str
+
+    :param local_dir: Directory where ``file_path`` will be placed
+    :type local_dir: str
 
     :return: tuple (path, is_local) where
-             <path> is a path starting at <local_dir> suitable for storing
-                    a link to, or the contents of, <fpath>
-             <is_local> is a bool, true iff <fpath> is already a
-                    descendant of <local_dir>
+             ``path`` is a path starting at ``local_dir`` suitable for storing
+                    a link to, or the contents of, ``file_path``
+             ``is_local`` is a bool, true iff ``file_path`` is already a
+                    descendant of ``local_dir``
+    :rtype: Tuple[str, bool]
 
-    .. note:: Different <fname> values may map to the same local path
+    .. note:: Different ``fname`` values may map to the same local path
+    .. note:: Expects arguments to already be unraveled.
     """
-    import os.path as p
-
-    if not isinstance(fpath, StringType):
+    if not isinstance(file_path, StringType):
         raise TypeError("fpath must be of type str (%r has type %s)" %
-                        (fpath, type(fpath)))
+                        (file_path, type(file_path)))
 
     if not isinstance(local_dir, StringType):
         raise TypeError("local_dir must be of type str (%r has type %s)" %
                         (local_dir, type(local_dir)))
 
-    if not fpath:
-        raise ValueError("Path %r is not a valid filename" % fpath)
+    if not file_path:
+        raise ValueError("Path %r is not a valid filename" % file_path)
 
-    abs_fpath = p.realpath(fpath)
-    abs_local_dir = p.realpath(local_dir)
+    abs_file_path = os.path.realpath(file_path)
+    abs_local_dir = os.path.realpath(local_dir)
 
     # A bit clunky but works okay for now
-    if abs_fpath.startswith(abs_local_dir):
+    if abs_file_path.startswith(abs_local_dir):
         is_local = True
-        local_relative_path = abs_fpath[len(abs_local_dir + os.path.sep):]
+        local_relative_path = abs_file_path[len(abs_local_dir + os.path.sep):]
     else:
         is_local = False
-        local_relative_path = os.path.basename(abs_fpath)
+        local_relative_path = os.path.basename(abs_file_path)
 
-    return (os.path.join(local_dir, local_relative_path), is_local)
+    return os.path.join(local_dir, local_relative_path), is_local
 
 
-def _prepare_file_input(orig_fname, local_dir, resolvers=None):
-    """
-    Given an arbitrary filename, determine whether that file is a child of
-    <local_dir>. If not, create a symlink under <local_dir> that points to the
-    original file, so the Jupyter server can resolve it.
+def _prepare_file_input(orig_file_name, local_dir, resolvers=None):
+    """Given an arbitrary filename, determine whether that file is a child of
+    ``local_dir``. If not, create a symlink under ``local_dir`` that points
+    to the original file, so the Jupyter server can resolve it.
+
+    :param orig_file_name: Some arbitrary file that we want to put under
+                           ``local_dir``
+    :type orig_file_name: str
+
+    :param local_dir: The directory where we'll either check if
+                      ``orig_file_name`` exists under, or where we'll
+                      link ``orig_file_name``
+    :type local_dir: str
 
     :param resolvers: sequence of callables to be applied, in order, to
-    <orig_fname>. Could be used to normalize case, look up bare paths in
-    system- specific search paths, etc. <orig_fname> will have environment
-    variables and user directories expanded before it is given to the first
-    resolver.
+                      ``orig_file_name``. Could be used to normalize case,
+                      look up bare paths in system-specific search paths, etc.
+                      ``orig_file_name`` will have environment variables and
+                      user directories expanded before it is given to the
+                      first resolver.
+    :type resolvers: Optional[Sequence[function]]
 
-    :return: A filename in the local filesystem, under <local_dir>
+    :return: A filename in the local filesystem, under ``local_dir``
+    :rtype: str
     """
-    input_path = _unravel_path(orig_fname, resolvers)
+    input_path = _unravel_path(orig_file_name, resolvers=resolvers)
 
-    # TODO (sat 2018-11-07): Handle errors more thoroughly
-    # * unable to make local path
-    # * symlink already exists, to wrong target
-    # * original file does not exist / has bad perms
+    # TODO: Handle errors more thoroughly
+    #       * unable to make local path
+    #       * symlink already exists, to wrong target
+    #       * original file does not exist / has bad perms
     _require_dir(local_dir)
 
-    # TODO (sat 2018-11-07): Do the right thing if <local_dir> is absolute
+    # TODO (sat 2018-11-07): Do the right thing if ``local_dir`` is absolute
     local_fname, is_local = _local_name_for_file(input_path, local_dir)
     if not is_local:
         try:
-            # Note that _unravel_path keeps relative names like ../foo.tmp
+            # Note that ``_unravel_path`` keeps relative names like ../foo.tmp
             # will as is, only applying user specifications like ~someone,
             # environment variables, and any explicit resolvers. This is
             # intended to make links as human-comprehensible as possible.
@@ -406,38 +432,65 @@ def _prepare_file_input(orig_fname, local_dir, resolvers=None):
 
 
 def _split_inputs(orig_inputs):
-    """
-    Given an input specification containing one or more filesystem paths and
+    """Given an input specification containing one or more filesystem paths and
     URIs separated by '|', return a list of individual inputs.
 
     * Skips blank entries
     * Removes blank space around entries
+
+    :param orig_inputs: One or more filesystem paths and/or
+                        URIs separated by '|'
+    :type orig_inputs: str
+
+    :return: List of the individual inputs specified in ``orig_inputs``
+    :rtype: list(str)
+
+    :Example:
+    >>> from sigplot import _split_inputs
+    >>> _split_inputs('foo|bar')
+    ['foo', 'bar']
     """
     # (sat 2018-11-19): If we want to support direct list inputs, this is the
     # place to handle that.
-    inputs = orig_inputs.split('|')
-    inputs = [ii.strip() for ii in inputs]
-    inputs = [ii for ii in inputs if ii]
-    return inputs
+    return [ii.strip() for ii in orig_inputs.split('|') if ii.strip()]
 
 
-def _prepare_href_input(orig_inputs, local_dir, resolvers=None):
-    """
-    Given an input specification containing one or more filesystem paths and
+def _prepare_href_input(orig_inputs, local_dir, progress=None, resolvers=None):
+    """Given an input specification containing one or more filesystem paths and
     URIs separated by '|', prepare each one according to its type.
 
-    :return: A list of filenames in the local filesystem, under <local_dir>
+    :param orig_inputs: One or more filesystem paths
+                        and/or URIs separated by '|'
+    :type orig_inputs: str
+
+    :param local_dir: Directory where the ``orig_inputs`` will end up
+    :type local_dir: Optional[str]
+
+    :param progress: Optional progress traitlet to provide
+                     feedback to the client
+    :type progress: Optional[traitlets.Float]
+
+    :param resolvers: sequence of callables to be applied, in order, to
+                      ``orig_file_name``. Could be used to normalize case,
+                      look up bare paths in system-specific search paths, etc.
+                      ``orig_file_name`` will have environment variables and
+                      user directories expanded before it is given to the
+                      first resolver.
+    :type resolvers: Optional[Sequence[function]]
+
+    :return: A list of filenames in the local filesystem, under ``local_dir``
+    :rtype: list(str)
     """
     prepared = []
 
     for oi in _split_inputs(orig_inputs):
         if oi.startswith("http"):
-            pi = _prepare_http_input(oi, local_dir)
+            pi = _prepare_http_input(oi, local_dir, progress=progress)
         else:
-            # TODO (sat 2019-01-08): This `resolvers` argument  feels like a
-            # bad factoring, since only one branch uses it; may want to move
-            # _prepare_href_input to a class member or else replace with a
-            # split+dispatch idiom at the point of call.
+            # TODO: This `resolvers` argument  feels like a bad factoring,
+            #       since only one branch uses it; may want to move
+            #       _prepare_href_input to a class member or else replace
+            #       with a split+dispatch idiom at the point of call.
             pi = _prepare_file_input(oi, local_dir, resolvers)
         prepared.append(pi)
     return prepared


### PR DESCRIPTION
Addresses #13, #36, and indirectly #11. This also includes adding a traitlet for `progress` when downloading a remote asset. Also, this changes the name from `sigplot.SigPlot` to `sigplot.Plot` to match the JS.

## TODO:
- [x] Back-end
    - [x] Refactor
    - [x] Test
        - [x] Test 1-D plotting
        - [x] Test 2-D plotting (with 2-D arrays as well as 1-D arrays both with subsize)
- [x] Front-end
    - [x] Refactor
    - [x] Test
        - [x] Test `change_settings`
        - [x] Test `overlay_array`
        - [x] Test `overlay_href`
            - [x] Test single local href
            - [x] Test single remote href
            - [x] Test two hrefs delimited by '|'
- [x] Optimize array passing by using binary serialization

Will do in subsequent PRs:
- Determine how to handle `plot.get_layer(lyr)` and other such methods
- Ensure progress updates work and print appropriately (tqdm-style?)
- Figure out how to handle passing callback functions